### PR TITLE
Add document QA web app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Document Question Answering Web App
+
+This project demonstrates how to build a simple website that lets you upload PDF, Word, or Excel files and ask questions about their contents using an open source language model.
+
+## Requirements
+
+- Python 3.11+
+- Packages in `requirements.txt`
+
+Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+The first time you run this it will download open-source models (e.g., `flan-t5-small`).
+
+## Running the Web App
+
+```bash
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser. Upload documents and submit questions.
+
+## Mobile App Idea
+
+You can create a simple mobile app (React Native, Flutter, or any framework) that sends file uploads and questions to the same Flask backend. The backend responds with the answer in JSON or HTML.
+
+For production, you might deploy the Flask server and call it from your mobile app via HTTP.
+
+## Notes
+
+- This is a minimal example for local experimentation. For large documents or heavy usage, consider using a more robust vector store and model hosting solution.
+- Google NotebookLM is another option if you prefer a managed solution from Google.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,77 @@
+import os
+from flask import Flask, request, render_template, redirect
+
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import FAISS
+from langchain.llms import HuggingFacePipeline
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.chains import RetrievalQA
+
+import pandas as pd
+from pypdf import PdfReader
+from docx import Document
+
+app = Flask(__name__)
+
+vector_store = None
+
+# Initialize models
+embeddings = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+llm = HuggingFacePipeline.from_model_id(
+    model_id="google/flan-t5-small",
+    task="text2text-generation",
+    device=0 if os.environ.get("USE_GPU") else -1,
+)
+text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+
+
+def extract_text(file_path):
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext == ".pdf":
+        reader = PdfReader(file_path)
+        return "\n".join(page.extract_text() for page in reader.pages if page.extract_text())
+    elif ext in [".doc", ".docx"]:
+        doc = Document(file_path)
+        return "\n".join(p.text for p in doc.paragraphs)
+    elif ext in [".xls", ".xlsx"]:
+        df = pd.read_excel(file_path, sheet_name=None)
+        return "\n".join(df[s].to_string() for s in df)
+    else:
+        with open(file_path, "r", errors="ignore") as f:
+            return f.read()
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("index.html")
+
+
+@app.route("/upload", methods=["POST"])
+def upload():
+    global vector_store
+    texts = []
+    for f in request.files.getlist("files"):
+        path = os.path.join("uploads", f.filename)
+        os.makedirs("uploads", exist_ok=True)
+        f.save(path)
+        text = extract_text(path)
+        docs = text_splitter.create_documents([text])
+        texts.extend(docs)
+    if texts:
+        vector_store = FAISS.from_documents(texts, embeddings)
+    return redirect("/")
+
+
+@app.route("/ask", methods=["POST"])
+def ask():
+    global vector_store
+    if vector_store is None:
+        return render_template("index.html", answer="No documents uploaded yet")
+    question = request.form.get("question")
+    qa = RetrievalQA.from_chain_type(llm=llm, chain_type="stuff", retriever=vector_store.as_retriever())
+    answer = qa.run(question)
+    return render_template("index.html", answer=answer)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+flask
+langchain
+faiss-cpu
+sentence-transformers
+transformers
+pypdf
+python-docx
+pandas

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Document QA</title>
+</head>
+<body>
+    <h1>Upload Documents</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="files" multiple>
+        <input type="submit" value="Upload">
+    </form>
+    <h2>Ask Question</h2>
+    <form action="/ask" method="post">
+        <input type="text" name="question" size="80">
+        <input type="submit" value="Ask">
+    </form>
+    {% if answer %}
+    <h3>Answer:</h3>
+    <p>{{ answer }}</p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple Flask app for question answering over PDF, Word, and Excel files using open source models
- include HTML frontend
- add basic instructions and dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ac262fa48329912eed268ff4bd50